### PR TITLE
Compact cache key

### DIFF
--- a/memcache/appengine.go
+++ b/memcache/appengine.go
@@ -29,7 +29,7 @@ type Cache struct {
 func cacheKey(key string) string {
 	md5 := md5.Sum([]byte(key))
 
-	return "httpcache:" + fmt.Sprintf("%x", md5)
+	return fmt.Sprintf("httpcache:%x", md5)
 }
 
 // Get returns the response corresponding to key if present.

--- a/memcache/appengine.go
+++ b/memcache/appengine.go
@@ -9,6 +9,9 @@
 package memcache
 
 import (
+	"crypto/md5"
+	"fmt"
+
 	"appengine"
 	"appengine/memcache"
 )
@@ -20,9 +23,13 @@ type Cache struct {
 }
 
 // cacheKey modifies an httpcache key for use in memcache.  Specifically, it
-// prefixes keys to avoid collision with other data stored in memcache.
+// prefixes keys to avoid collision with other data stored in memcache. It
+// also uses the MD5 hash of the key in order to avoid exceeding the 250
+// character length limit for a memcache key.
 func cacheKey(key string) string {
-	return "httpcache:" + key
+	md5 := md5.Sum([]byte(key))
+
+	return "httpcache:" + fmt.Sprintf("%x", md5)
 }
 
 // Get returns the response corresponding to key if present.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -9,6 +9,9 @@
 package memcache
 
 import (
+	"crypto/md5"
+	"fmt"
+
 	"github.com/bradfitz/gomemcache/memcache"
 )
 
@@ -19,9 +22,13 @@ type Cache struct {
 }
 
 // cacheKey modifies an httpcache key for use in memcache.  Specifically, it
-// prefixes keys to avoid collision with other data stored in memcache.
+// prefixes keys to avoid collision with other data stored in memcache. It
+// also uses the MD5 hash of the key in order to avoid exceeding the 250
+// character length limit for a memcache key.
 func cacheKey(key string) string {
-	return "httpcache:" + key
+	md5 := md5.Sum([]byte(key))
+
+	return "httpcache:" + fmt.Sprintf("%x", md5)
 }
 
 // Get returns the response corresponding to key if present.

--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -28,7 +28,7 @@ type Cache struct {
 func cacheKey(key string) string {
 	md5 := md5.Sum([]byte(key))
 
-	return "httpcache:" + fmt.Sprintf("%x", md5)
+	return fmt.Sprintf("httpcache:%x", md5)
 }
 
 // Get returns the response corresponding to key if present.


### PR DESCRIPTION
# Problem
Very long URLs are failing to cache. There is a limit of 250 characters for memcached keys:

https://github.com/memcached/memcached/wiki/Commands#standard-protocol

# Solution
Use the MD5 sum of the passed in key (URL and possibly method name) to generate a consistent, but shorter cache key.

@shopsmart/web-team 